### PR TITLE
fix: 앱 실행 후, 처음에 탭 레이아웃에 색상이 적용 안되는 문제 해결

### DIFF
--- a/app/src/main/java/com/mediseed/mediseed/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/mediseed/mediseed/ui/main/MainActivity.kt
@@ -33,23 +33,5 @@ class MainActivity : AppCompatActivity() {
             tab.setText(viewPagerAdapter.getTitle(position))
             tab.setIcon(viewPagerAdapter.getTabIcon(position))
         }.attach()
-
-        tlMain.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
-            override fun onTabSelected(tab: TabLayout.Tab?) {
-                tab?.let {
-                    it.icon?.setTint(getColor(R.color.green_300))
-                }
-            }
-
-            override fun onTabUnselected(tab: TabLayout.Tab?) {
-                tab?.let {
-                    it.icon?.setTint(getColor(R.color.grey))
-                }
-            }
-
-            override fun onTabReselected(tab: TabLayout.Tab?) {
-                // 재선택 시
-            }
-        })
     }
 }

--- a/app/src/main/res/drawable/selector_tab_color.xml
+++ b/app/src/main/res/drawable/selector_tab_color.xml
@@ -1,0 +1,5 @@
+<!-- res/color/tab_icon_color_selector.xml -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/green_300" android:state_selected="true" />
+    <item android:color="@color/grey" />
+</selector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -19,8 +19,10 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:tabIndicatorHeight="0dp"
+        app:tabRippleColor="@null"
         android:background="@drawable/shape_tab_layout"
-        app:tabSelectedTextColor="@color/green_300"
+        app:tabTextColor="@drawable/selector_tab_color"
+        app:tabIconTint="@drawable/selector_tab_color"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />


### PR DESCRIPTION
- 구현한 기능:  
    - [x] 코드로 색상 변경하는 대신 XML에서 selector 사용 

- 구현 이미지:
<p align="center">
  <img src="https://github.com/BanDalKang/Medi_seed/assets/77070839/fed755dd-ec1a-4277-b2a2-9af068dd25b8" width="40%">
  <img src="https://github.com/BanDalKang/Medi_seed/assets/77070839/6f2d0d4c-4710-4aa4-9996-63e1334a4fe8" width="40%">
</p>